### PR TITLE
Fix character escaping in LDAP search filters

### DIFF
--- a/Linq2Ldap.Core.Tests/FilterCompiler/LDAPFilterCompilerTests.cs
+++ b/Linq2Ldap.Core.Tests/FilterCompiler/LDAPFilterCompilerTests.cs
@@ -46,6 +46,13 @@ namespace Linq2Ldap.Core.Tests.FilterCompiler
         }
 
         [Fact]
+        public void Compile_ValueWithGermanUmlauts() {
+            Expression<Func<TestLdapModel, bool>> expr = e => e.DistinguishedName == "CN=Domänen-Admins,CN=Users,DC=domain,DC=de";
+            var filter = FilterCompiler.Compile(expr);
+            Assert.Equal(@"(distinguishedName=CN=Dom\c3\a4nen-Admins,CN=Users,DC=domain,DC=de)", filter);
+        }
+
+        [Fact]
         public void _MemberToString_DataSourceModel_SerializesByColumnAttrWhenAvailable()
         {
             Expression<Func<TestLdapModel, bool>> expr1 = (TestLdapModel u) => u.SamAccountName == "something";

--- a/Linq2Ldap.Core.Tests/FilterCompiler/TestLdapModel.cs
+++ b/Linq2Ldap.Core.Tests/FilterCompiler/TestLdapModel.cs
@@ -23,6 +23,9 @@ namespace Linq2Ldap.Core.Tests.FilterCompiler
         [LdapField("cn")]
         public string CommonName { get; set; }
 
+        [LdapField("distinguishedName")]
+        public string DistinguishedName { get; set; }
+
         [LdapField("id")]
         public LdapInt Id { get; set; }
 
@@ -31,5 +34,7 @@ namespace Linq2Ldap.Core.Tests.FilterCompiler
 
         [LdapField(" we ird  ")]
         public LdapString WeirdName { get; set; }
+
+
     }
 }


### PR DESCRIPTION
Allow multi-byte UTF8 characters in LDAP search filter. Fixes a problem with German umlauts. 'Über' will be escaped to: \c3\9cber.
