### PR TITLE
Funktionality extension search with guid

### DIFF
--- a/Linq2Ldap.Core.Tests/ExtensionMethods/GuidExtensionsTests.cs
+++ b/Linq2Ldap.Core.Tests/ExtensionMethods/GuidExtensionsTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Linq2Ldap.Core.ExtensionMethods;
-using Linq2Ldap.Core.Tests.FilterCompiler;
 using Xunit;
 
 namespace Linq2Ldap.Core.Tests.ExtensionMethods

--- a/Linq2Ldap.Core.Tests/ExtensionMethods/GuidExtensionsTests.cs
+++ b/Linq2Ldap.Core.Tests/ExtensionMethods/GuidExtensionsTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Linq2Ldap.Core.ExtensionMethods;
+using Linq2Ldap.Core.Tests.FilterCompiler;
+using Xunit;
+
+namespace Linq2Ldap.Core.Tests.ExtensionMethods
+{
+    public class GuidExtensionsTests
+    {
+        [Fact]
+        public void ToEscapedBytesString_Guid()
+        {
+            var guid = new Guid("96AA667A-E58E-486D-9114-CB1EDC5E2B0D");
+            var result = guid.ToEscapedBytesString();
+            Assert.Equal(@"\7a\66\aa\96\8e\e5\6d\48\91\14\cb\1e\dc\5e\2b\0d", result);
+        }
+
+        [Fact]
+        public void ToEscapedBytesString_BytesArray()
+        {
+            var bytes = new Guid("96AA667A-E58E-486D-9114-CB1EDC5E2B0D").ToByteArray();
+            var result = bytes.ToEscapedBytesString();
+            Assert.Equal(@"\7a\66\aa\96\8e\e5\6d\48\91\14\cb\1e\dc\5e\2b\0d", result);
+        }
+    }
+}

--- a/Linq2Ldap.Core.Tests/ExtensionMethods/GuidExtensionsTests.cs
+++ b/Linq2Ldap.Core.Tests/ExtensionMethods/GuidExtensionsTests.cs
@@ -17,9 +17,9 @@ namespace Linq2Ldap.Core.Tests.ExtensionMethods
         [Fact]
         public void ToEscapedBytesString_BytesArray()
         {
-            var bytes = new Guid("96AA667A-E58E-486D-9114-CB1EDC5E2B0D").ToByteArray();
+            var bytes = new byte[] {0xAB, 0x12, 0xFF, 0x00};
             var result = bytes.ToEscapedBytesString();
-            Assert.Equal(@"\7a\66\aa\96\8e\e5\6d\48\91\14\cb\1e\dc\5e\2b\0d", result);
+            Assert.Equal(@"\ab\12\ff\00", result);
         }
     }
 }

--- a/Linq2Ldap.Core.Tests/FilterCompiler/LDAPFilterCompilerTests.cs
+++ b/Linq2Ldap.Core.Tests/FilterCompiler/LDAPFilterCompilerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using Linq2Ldap.Core.FilterCompiler;
@@ -178,6 +179,20 @@ namespace Linq2Ldap.Core.Tests.FilterCompiler
             var ex = Assert.Throws<InvalidOperationException>(() => FilterCompiler.Compile(expr));
             Assert.Contains("Right side", ex.Message);
             Assert.Contains("must be a constant", ex.Message);
+        }
+
+        [Fact]
+        public void Compile_SearchWithObjectGUIDAsByteArray()
+        {
+            var guid = new Guid("96AA667A-E58E-486D-9114-CB1EDC5E2B0D");
+            Expression<Func<TestLdapModel, bool>> expr = e => e.ObjectGuid == guid;
+
+            var filter = FilterCompiler.Compile(expr);
+
+            var bytes = guid.ToByteArray();
+            
+            var ldapGuid = string.Join("", bytes.Select(b => $"\\{b:x2}"));
+            Assert.Equal($@"(objectGUID={ldapGuid})", filter);
         }
     }
 

--- a/Linq2Ldap.Core.Tests/FilterCompiler/LDAPFilterCompilerTests.cs
+++ b/Linq2Ldap.Core.Tests/FilterCompiler/LDAPFilterCompilerTests.cs
@@ -186,13 +186,8 @@ namespace Linq2Ldap.Core.Tests.FilterCompiler
         {
             var guid = new Guid("96AA667A-E58E-486D-9114-CB1EDC5E2B0D");
             Expression<Func<TestLdapModel, bool>> expr = e => e.ObjectGuid == guid;
-
             var filter = FilterCompiler.Compile(expr);
-
-            var bytes = guid.ToByteArray();
-            
-            var ldapGuid = string.Join("", bytes.Select(b => $"\\{b:x2}"));
-            Assert.Equal($@"(objectGUID={ldapGuid})", filter);
+            Assert.Equal($@"(objectGUID=\7a\66\aa\96\8e\e5\6d\48\91\14\cb\1e\dc\5e\2b\0d)", filter);
         }
     }
 

--- a/Linq2Ldap.Core.Tests/FilterCompiler/TestLdapModel.cs
+++ b/Linq2Ldap.Core.Tests/FilterCompiler/TestLdapModel.cs
@@ -1,3 +1,4 @@
+using System;
 using Linq2Ldap.Core.Attributes;
 using Linq2Ldap.Core.Models;
 using Linq2Ldap.Core.Types;
@@ -35,6 +36,7 @@ namespace Linq2Ldap.Core.Tests.FilterCompiler
         [LdapField(" we ird  ")]
         public LdapString WeirdName { get; set; }
 
-
+        [LdapField("objectGUID")]
+        public Guid ObjectGuid { get; set; }
     }
 }

--- a/Linq2Ldap.Core/ExtensionMethods/GuidExtensions.cs
+++ b/Linq2Ldap.Core/ExtensionMethods/GuidExtensions.cs
@@ -11,13 +11,13 @@ namespace Linq2Ldap.Core.ExtensionMethods
         /// <summary>
         /// Return a string of bytes of the source GUID
         /// </summary>
-        /// <param name="guid">The GUID to convert</param>
+        /// <param name="guid">The GUID to return</param>
         /// <returns></returns>
         public static string ToEscapedBytesString(this Guid guid) => 
             guid.ToByteArray().ToEscapedBytesString();
 
         /// <summary>
-        /// Return a string of bytes of the source GUID
+        /// Return a string of bytes of the source bytes array
         /// </summary>
         /// <param name="array">The bytes to return</param>
         /// <returns></returns>

--- a/Linq2Ldap.Core/ExtensionMethods/GuidExtensions.cs
+++ b/Linq2Ldap.Core/ExtensionMethods/GuidExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Linq;
+
+namespace Linq2Ldap.Core.ExtensionMethods
+{
+    /// <summary>
+    /// Helper class for working with GUID
+    /// </summary>
+    public static class GuidExtensions
+    {
+        /// <summary>
+        /// Return a string of bytes of the source GUID
+        /// </summary>
+        /// <param name="guid">The GUID to convert</param>
+        /// <returns></returns>
+        public static object ToEscapedBytesString(this Guid guid)
+        {
+            return string.Join("", guid.ToByteArray().Select(b => $"\\{b:x2}"));
+        }
+    }
+}

--- a/Linq2Ldap.Core/ExtensionMethods/GuidExtensions.cs
+++ b/Linq2Ldap.Core/ExtensionMethods/GuidExtensions.cs
@@ -13,9 +13,15 @@ namespace Linq2Ldap.Core.ExtensionMethods
         /// </summary>
         /// <param name="guid">The GUID to convert</param>
         /// <returns></returns>
-        public static object ToEscapedBytesString(this Guid guid)
-        {
-            return string.Join("", guid.ToByteArray().Select(b => $"\\{b:x2}"));
-        }
+        public static string ToEscapedBytesString(this Guid guid) => 
+            guid.ToByteArray().ToEscapedBytesString();
+
+        /// <summary>
+        /// Return a string of bytes of the source GUID
+        /// </summary>
+        /// <param name="array">The bytes to return</param>
+        /// <returns></returns>
+        public static string ToEscapedBytesString(this byte[] array) => 
+            string.Join("", array.Select(b => $"\\{b:x2}"));
     }
 }

--- a/Linq2Ldap.Core/FilterCompiler/ValueUtil.cs
+++ b/Linq2Ldap.Core/FilterCompiler/ValueUtil.cs
@@ -47,8 +47,7 @@ namespace Linq2Ldap.Core.FilterCompiler {
         {
             if (c >= 0x01 && c <= 0x27 ||
                 c >= 0x2B && c <= 0x5B ||
-                c >= 0x5D && c <= 0x7F ||
-                c == 0x5C)
+                c >= 0x5D && c <= 0x7F)
             {
                 // https://tools.ietf.org/search/rfc4515#page-4 - see 'UTF1SUBSET'
                 yield return c;

--- a/Linq2Ldap.Core/FilterCompiler/ValueUtil.cs
+++ b/Linq2Ldap.Core/FilterCompiler/ValueUtil.cs
@@ -47,7 +47,8 @@ namespace Linq2Ldap.Core.FilterCompiler {
         {
             if (c >= 0x01 && c <= 0x27 ||
                 c >= 0x2B && c <= 0x5B ||
-                c >= 0x5D && c <= 0x7F)
+                c >= 0x5D && c <= 0x7F ||
+                c == 0x5C)
             {
                 // https://tools.ietf.org/search/rfc4515#page-4 - see 'UTF1SUBSET'
                 yield return c;


### PR DESCRIPTION
Hello Chris,
I use your library 'linq2ldap' and think it's cool.
But there is a problem with searching with objectGUID.
The Problem has been known for a long time, objectGUID with GUID value as string (for example C6E74318-EC4F-4DFD-890D-116562A4E08D) does not work. You can read about this Problem here: https://stackoverflow.com/questions/1545630/searching-for-a-objectguid-in-ad or here: https://github.com/gheeres/node-activedirectory/issues/61.
I've expanded your library so that type of search can work. Also I wrote some new UnitTest.
Best regards
Sergey Tikhonov